### PR TITLE
Fix: load credentials to frontend

### DIFF
--- a/DataciteExportPlugin.inc.php
+++ b/DataciteExportPlugin.inc.php
@@ -182,11 +182,10 @@ class DataciteExportPlugin extends ImportExportPlugin
 			$this->updateSetting( $contextId, 'api', $userVars['api'] );
 			$this->updateSetting( $contextId, 'daraMode', $userVars['daraMode'] );
 			$this->updateSetting( $contextId, 'username', $userVars['username'] );
-			$this->updateSetting( $contextId, 'password', $userVars['password'] );
-			$this->updateSetting( $contextId, 'testMode', $userVars['testMode'] );
-			$this->updateSetting( $contextId, 'testPrefix', $userVars['testPrefix'] );
-			$this->updateSetting( $contextId, 'testRegistry', $userVars['testRegistry'] );
-			$this->updateSetting( $contextId, 'testUrl', $userVars['testUrl'] );
+			if( NULL !== $userVars['password'] && !empty( $userVars['password'] ) )
+			{
+				$this->updateSetting( $contextId, 'password', $userVars['password'] );
+			}
 		}
 	}
 

--- a/DataciteExportPlugin.inc.php
+++ b/DataciteExportPlugin.inc.php
@@ -1223,7 +1223,6 @@ class DataciteExportPlugin extends ImportExportPlugin
 	public function register( $category, $path, $mainContextId = NULL ) : bool
 	{
 
-		HookRegistry::register( 'PKPLocale::registerLocaleFile', array( &$this, 'addCustomLocale' ) );
 		HookRegistry::register( 'LoadComponentHandler', array( $this, 'setupGridHandler' ) );
 		HookRegistry::register(
 			'Templates::Management::Settings::website', array( $this, 'callbackShowWebsiteSettingsTabs' )

--- a/templates/index.tpl
+++ b/templates/index.tpl
@@ -48,7 +48,7 @@
 			{fbvFormSection}
 			{fbvElement type="text" id="api" value=$api label="plugins.importexport.datacite.settings.form.url" maxlength="100" size=$fbvStyles.size.MEDIUM}
 			{fbvElement type="text" id="username" value=$username label="plugins.importexport.datacite.settings.form.username" maxlength="50" size=$fbvStyles.size.MEDIUM}
-			{fbvElement type="text" password="true" id="password" value=$password label="plugins.importexport.datacite.settings.form.password" maxLength="50" size=$fbvStyles.size.MEDIUM}
+			{fbvElement type="text" password="true" id="password" value="" label="plugins.importexport.datacite.settings.form.password" maxLength="50" size=$fbvStyles.size.MEDIUM}
 				<span class="instruct">{translate key="plugins.importexport.datacite.settings.form.password.description"}</span>
 				<br/>
 			{/fbvFormSection}


### PR DESCRIPTION
[https://forum.pkp.sfu.ca/t/datacite-plugin-not-multi-journal-ready-dont-load-credentials-to-frontend/66559](https://forum.pkp.sfu.ca/t/datacite-plugin-not-multi-journal-ready-dont-load-credentials-to-frontend/66559l)

This fix removes the password from setting-page. Save-button changes password now only, if is not null or empty.  